### PR TITLE
Added the first Implementation for Custom Plugin Events

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from src.backend.AssetManagerBackend import AssetManagerBackend
     from src.windows.AssetManager.AssetManager import AssetManager
     from src.backend.MediaManager import MediaManager
-    from src.backend.PageManagement.PageManager import PageManager
+    from src.backend.PageManagement.PageManagerBackend import PageManagerBackend
     from src.backend.SettingsManager import SettingsManager
     from src.backend.DeckManagement.DeckManager import DeckManager
     from src.backend.PluginManager.PluginManager import PluginManager
@@ -43,7 +43,7 @@ lm:"LocaleManager" = None
 media_manager:"MediaManager" = None #MediaManager
 asset_manager_backend:"AssetManagerBackend" = None #AssetManager
 asset_manager: "AssetManager" = None
-page_manager:"PageManager" = None #PageManager
+page_manager_backend:"PageManagerBackend" = None #PageManager
 gnome_extensions:"GnomeExtensions" = None
 settings_manager:"SettingsManager" = None #SettingsManager
 app:"App" = None #App

--- a/globals.py
+++ b/globals.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from src.backend.GnomeExtensions import GnomeExtensions
     from src.windows.Store.Store import Store
     from src.backend.PermissionManagement.FlatpakPermissionManager import FlatpakPermissionManager
+    from src.windows.PageManager.PageManager import PageManager
 
 
 top_level_dir:str = os.path.dirname(__file__)
@@ -43,6 +44,7 @@ lm:"LocaleManager" = None
 media_manager:"MediaManager" = None #MediaManager
 asset_manager_backend:"AssetManagerBackend" = None #AssetManager
 asset_manager: "AssetManager" = None
+page_manager: "PageManager" = None # Only if opened
 page_manager_backend:"PageManagerBackend" = None #PageManager
 gnome_extensions:"GnomeExtensions" = None
 settings_manager:"SettingsManager" = None #SettingsManager

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from src.backend.DeckManagement.DeckManager import DeckManager
 from locales.LocaleManager import LocaleManager
 from src.backend.MediaManager import MediaManager
 from src.backend.AssetManagerBackend import AssetManagerBackend
-from src.backend.PageManagement.PageManager import PageManager
+from src.backend.PageManagement.PageManagerBackend import PageManagerBackend
 from src.backend.SettingsManager import SettingsManager
 from src.backend.PluginManager.PluginManager import PluginManager
 from src.backend.DeckManagement.HelperMethods import get_sys_args_without_param
@@ -101,7 +101,7 @@ def create_global_objects():
 
     gl.media_manager = MediaManager()
     gl.asset_manager_backend = AssetManagerBackend()
-    gl.page_manager = PageManager(gl.settings_manager)
+    gl.page_manager_backend = PageManagerBackend(gl.settings_manager)
     gl.icon_pack_manager = IconPackManager()
     gl.wallpaper_pack_manager = WallpaperPackManager()
 

--- a/src/backend/AssetManagerBackend.py
+++ b/src/backend/AssetManagerBackend.py
@@ -125,7 +125,7 @@ class AssetManagerBackend(list):
         
         internal_path = asset["internal-path"]
 
-        gl.page_manager.remove_asset_from_all_pages(internal_path)
+        gl.page_manager_backend.remove_asset_from_all_pages(internal_path)
 
         os.remove(internal_path)
 

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -360,18 +360,18 @@ class DeckController:
 
     def load_default_page(self):
         if not self.get_alive(): return
-        default_page_path = gl.page_manager.get_default_page_for_deck(self.deck.get_serial_number())
+        default_page_path = gl.page_manager_backend.get_default_page_for_deck(self.deck.get_serial_number())
         if default_page_path is None:
             # Use the first page
-            pages = gl.page_manager.get_pages()
+            pages = gl.page_manager_backend.get_pages()
             if len(pages) == 0:
                 return
-            default_page_path = gl.page_manager.get_pages()[0]
+            default_page_path = gl.page_manager_backend.get_pages()[0]
 
         if default_page_path is None:
             return
         
-        page = gl.page_manager.get_page(default_page_path, self)
+        page = gl.page_manager_backend.get_page(default_page_path, self)
         self.load_page(page)
 
     @log.catch

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -22,7 +22,7 @@ import os
 
 # Import own modules
 from src.backend.DeckManagement.DeckController import DeckController
-from src.backend.PageManagement.PageManager import PageManager
+from src.backend.PageManagement.PageManagerBackend import PageManagerBackend
 from src.backend.SettingsManager import SettingsManager
 from src.backend.DeckManagement.HelperMethods import get_sys_param_value, recursive_hasattr
 from src.backend.DeckManagement.Subclasses.FakeDeck import FakeDeck
@@ -39,7 +39,7 @@ class DeckManager:
         self.deck_controller: list[DeckController] = []
         self.fake_deck_controller = []
         self.settings_manager = SettingsManager()
-        self.page_manager = gl.page_manager
+        self.page_manager = gl.page_manager_backend
         # self.page_manager.load_pages()
 
         # USB monitor to detect connections and disconnections

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -52,7 +52,7 @@ class Page:
         Updates the dict without any updates on the action objects.
         Do NOT use if you made changes to the action objects
         """
-        self.dict = gl.page_manager.get_page_json(self.json_path)
+        self.dict = gl.page_manager_backend.get_page_json(self.json_path)
     
     def load(self, load_from_file: bool = False):
         start = time.time()

--- a/src/backend/PageManagement/PageManagerBackend.py
+++ b/src/backend/PageManagement/PageManagerBackend.py
@@ -28,7 +28,7 @@ from src.backend.DeckManagement.HelperMethods import recursive_hasattr
 # Import globals
 import globals as gl
 
-class PageManager:
+class PageManagerBackend:
     def __init__(self, settings_manager):
         self.settings_manager = settings_manager
 

--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -143,7 +143,7 @@ class PluginBase(rpyc.Service):
         )
 
     def register_page(self, path: str) -> None:
-        gl.page_manager.register_page(path)
+        gl.page_manager_backend.register_page(path)
 
     def get_selector_icon(self) -> Gtk.Widget:
         return Gtk.Image(icon_name="view-paged")

--- a/src/backend/WindowGrabber/WindowGrabber.py
+++ b/src/backend/WindowGrabber/WindowGrabber.py
@@ -83,11 +83,11 @@ class WindowGrabber:
         # log.info(f"Active window changed to: {window}")
         for deck_controller in gl.deck_manager.deck_controller:
             found_page = False
-            for page_path in gl.page_manager.get_pages():
+            for page_path in gl.page_manager_backend.get_pages():
                 abs_path = os.path.abspath(page_path)
-                if abs_path not in gl.page_manager.auto_change_info:
+                if abs_path not in gl.page_manager_backend.auto_change_info:
                     continue
-                info = gl.page_manager.auto_change_info[abs_path]
+                info = gl.page_manager_backend.auto_change_info[abs_path]
                 wm_regex = info.get("wm_class")
                 title_regex = info.get("title")
                 enabled = info.get("enable", False)
@@ -100,7 +100,7 @@ class WindowGrabber:
                     if deck_controller.active_page.json_path == page_path:
                         continue
                     log.debug(f"Auto changing page: {page_path} on deck {deck_controller.deck.get_serial_number()}")
-                    page = gl.page_manager.get_page(page_path, deck_controller)
+                    page = gl.page_manager_backend.get_page(page_path, deck_controller)
                     if not deck_controller.page_auto_loaded:
                         deck_controller.last_manual_loaded_page_path = deck_controller.active_page.json_path
                     deck_controller.load_page(page)
@@ -113,5 +113,5 @@ class WindowGrabber:
                     deck_controller.page_auto_loaded = False
                     if deck_controller.last_manual_loaded_page_path is None:
                         continue
-                    page = gl.page_manager.get_page(deck_controller.last_manual_loaded_page_path, deck_controller)
+                    page = gl.page_manager_backend.get_page(deck_controller.last_manual_loaded_page_path, deck_controller)
                     deck_controller.load_page(page, allow_reload=False)

--- a/src/windows/PageManager/Importer/Importer.py
+++ b/src/windows/PageManager/Importer/Importer.py
@@ -14,6 +14,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 # Import gi
 import os
+import threading
 import gi
 
 from src.windows.PageManager.Importer.StreamDeckUI.StreamDeckUI import StreamDeckUIImporter
@@ -51,12 +52,11 @@ class Importer(Adw.ApplicationWindow):
         self.progess_bar.set_fraction(0)
 
         if app == "streamdeck-ui":
-            self.import_from_streamdeck_ui(path)
+            thread = threading.Thread(target=self.import_from_streamdeck_ui, args=(path, ), name="import_from_streamdeck_ui")
+            thread.start()
 
-        self.progess_bar.set_text("Imported!")
-        self.progess_bar.set_fraction(1)
 
-        GLib.timeout_add(2000, self.close)
+        
 
     def import_from_streamdeck_ui(self, path: str) -> None:
         if not os.path.exists(path):
@@ -67,4 +67,9 @@ class Importer(Adw.ApplicationWindow):
             return
 
         ui_importer = StreamDeckUIImporter(path)
-        ui_importer.start_import()
+        ui_importer.perform_import()
+
+        GLib.idle_add(self.progess_bar.set_text, "Imported!")
+        GLib.idle_add(self.progess_bar.set_fraction, 1)
+
+        GLib.timeout_add(1500, self.close)

--- a/src/windows/PageManager/PageManager.py
+++ b/src/windows/PageManager/PageManager.py
@@ -65,7 +65,7 @@ class PageManager(Adw.ApplicationWindow):
         if os.path.exists(page_path):
             return
         
-        gl.page_manager.add_page(page_name)
+        gl.page_manager_backend.add_page(page_name)
         
         self.page_selector.add_row_by_path(page_path)
 
@@ -73,7 +73,7 @@ class PageManager(Adw.ApplicationWindow):
         gl.signal_manager.trigger_signal(Signals.PageAdd, page_path)
 
     def remove_page_by_path(self, page_path: str) -> None:
-        if page_path in gl.page_manager.custom_pages:
+        if page_path in gl.page_manager_backend.custom_pages:
             dial = CantDeletePluginPage(self)
             dial.show()
             return
@@ -84,7 +84,7 @@ class PageManager(Adw.ApplicationWindow):
         
         self.page_selector.remove_row_with_path(page_path)
 
-        gl.page_manager.remove_page(page_path)
+        gl.page_manager_backend.remove_page(page_path)
 
         # Emit signal
         gl.signal_manager.trigger_signal(Signals.PageDelete, page_path)
@@ -92,13 +92,13 @@ class PageManager(Adw.ApplicationWindow):
     def rename_page_by_path(self, old_path: str, new_path: str) -> None:
         self.page_selector.rename_page_row(old_path=old_path, new_path=new_path)
 
-        gl.page_manager.move_page(old_path, new_path)
+        gl.page_manager_backend.move_page(old_path, new_path)
 
         # Emit signal
         gl.signal_manager.trigger_signal(Signals.PageRename, old_path, new_path)
 
     def get_number_of_user_pages(self) -> int:
-        return len(gl.page_manager.get_pages(add_custom_pages=False))
+        return len(gl.page_manager_backend.get_pages(add_custom_pages=False))
     
 class CantDeleteLastPageError(Adw.MessageDialog):
     def __init__(self, page_manager: PageManager):

--- a/src/windows/PageManager/elements/MenuButton.py
+++ b/src/windows/PageManager/elements/MenuButton.py
@@ -61,10 +61,11 @@ class MenuButton(Gtk.MenuButton):
 
     def streamdeck_ui_callback(self, selected_file):
         importer = Importer(gl.app, self.pageEditor.page_manager)
-        GLib.idle_add(importer.present)
+        # GLib.idle_add(importer.present)
+        importer.present()
         importer.import_pages(selected_file.get_path(), "streamdeck-ui")
 
-        self.pageEditor.page_manager.page_selector.load_pages()
+        
 
 class ChooseFileDialog(Gtk.FileDialog):
     def __init__(self, menu_button: MenuButton, callback: callable = None):

--- a/src/windows/PageManager/elements/PageEditor.py
+++ b/src/windows/PageManager/elements/PageEditor.py
@@ -285,7 +285,7 @@ class DefaultPageGroup(Adw.PreferencesGroup):
         self.build()
 
     def build(self):
-        matches = gl.page_manager.get_all_deck_serial_numbers_with_page_as_default(path=self.page_editor.active_page_path)
+        matches = gl.page_manager_backend.get_all_deck_serial_numbers_with_page_as_default(path=self.page_editor.active_page_path)
         self.row = MultiDeckSelectorRow(source_window=self.page_editor.page_manager, title=gl.lm.get("page-manager.page-editor.default-page.row.title"),
                                         subtitle=gl.lm.get("page-manager.page-editor.default-page.row.subtitle"),
                                         callback=self.on_changed, selected_deck_serials=matches)
@@ -296,12 +296,12 @@ class DefaultPageGroup(Adw.PreferencesGroup):
         if not state:
             path = None
         
-        gl.page_manager.set_default_page_for_deck(serial_number=serial_number, path=path)
+        gl.page_manager_backend.set_default_page_for_deck(serial_number=serial_number, path=path)
 
     def load_for_page(self, page_path: str) -> None:
         self.update()
 
     def update(self) -> None:
-        matches = gl.page_manager.get_all_deck_serial_numbers_with_page_as_default(path=self.page_editor.active_page_path)
+        matches = gl.page_manager_backend.get_all_deck_serial_numbers_with_page_as_default(path=self.page_editor.active_page_path)
         self.row.set_label(len(matches))
         self.row.set_selected_deck_serials(matches)

--- a/src/windows/PageManager/elements/PageEditor.py
+++ b/src/windows/PageManager/elements/PageEditor.py
@@ -232,7 +232,7 @@ class AutoChangeGroup(Adw.PreferencesGroup):
             "wm_class": self.wm_class_entry.get_text(),
             "title": self.title_entry.get_text(),
         }
-        gl.page_manager.set_auto_change_info_for_page(page_path=self.page_editor.active_page_path,
+        gl.page_manager_backend.set_auto_change_info_for_page(page_path=self.page_editor.active_page_path,
                                                       info=auto_change)
 
     def load_config_settings(self):
@@ -242,7 +242,7 @@ class AutoChangeGroup(Adw.PreferencesGroup):
         
         self.disconnect_signals()
 
-        auto_change = gl.page_manager.get_auto_change_info_for_page(page_path=self.page_editor.active_page_path)
+        auto_change = gl.page_manager_backend.get_auto_change_info_for_page(page_path=self.page_editor.active_page_path)
 
         self.enable_row.set_active(auto_change.get("enable", False))
         self.wm_class_entry.set_text(auto_change.get("wm_class", ""))

--- a/src/windows/PageManager/elements/PageEditor.py
+++ b/src/windows/PageManager/elements/PageEditor.py
@@ -173,7 +173,7 @@ class NameGroup(Adw.PreferencesGroup):
         original_name = os.path.splitext(os.path.basename(self.page_editor.active_page_path))[0]
         new_name = entry.get_text()
 
-        all_page_names = gl.page_manager.get_page_names()
+        all_page_names = gl.page_manager_backend.get_page_names()
         all_page_names.remove(original_name)
         all_page_names.append("")
 

--- a/src/windows/PageManager/elements/PageSelector.py
+++ b/src/windows/PageManager/elements/PageSelector.py
@@ -77,7 +77,7 @@ class PageSelector(Adw.NavigationPage):
     def load_pages(self) -> None:
         self.page_rows.clear()
         self.list_box.remove_all()
-        pages = gl.page_manager.get_pages()
+        pages = gl.page_manager_backend.get_pages()
         for page_path in pages:
             self.add_row_by_path(page_path)
 

--- a/src/windows/PageManager/elements/PageSelector.py
+++ b/src/windows/PageManager/elements/PageSelector.py
@@ -151,7 +151,7 @@ class AddNewButton(Gtk.Button):
                            cancel_label=gl.lm.get("page-manager.page-selector.add-dialog.cancel"),
                            empty_warning=gl.lm.get("page-manager.page-selector.add-dialog.empty-warning"),
                            already_exists_warning=gl.lm.get("page-manager.page-selector.add-dialog.already-exists-warning"),
-                           forbid_answers=gl.page_manager.get_page_names())
+                           forbid_answers=gl.page_manager_backend.get_page_names())
         
         dial.show(callback_func=self.page_manager.add_page_from_name)
 

--- a/src/windows/Settings/Settings.py
+++ b/src/windows/Settings/Settings.py
@@ -237,7 +237,7 @@ class PerformancePageGroup(Adw.PreferencesGroup):
         self.settings.save_json()
 
         # Update value in page manager
-        gl.page_manager.set_n_pages_to_cache(int(self.n_cached_pages.get_value()))
+        gl.page_manager_backend.set_n_pages_to_cache(int(self.n_cached_pages.get_value()))
 
     def on_cache_videos_toggled(self, *args):
         self.settings.settings_json.setdefault("performance", {})

--- a/src/windows/mainWindow/elements/NoPagesError.py
+++ b/src/windows/mainWindow/elements/NoPagesError.py
@@ -65,12 +65,12 @@ class NoPagesError(Gtk.Box):
                            cancel_label=gl.lm.get("page-manager.page-selector.add-dialog.cancel"),
                            empty_warning=gl.lm.get("page-manager.page-selector.add-dialog.empty-warning"),
                            already_exists_warning=gl.lm.get("page-manager.page-selector.add-dialog.already-exists-warning"),
-                           forbid_answers=gl.page_manager.get_page_names())
+                           forbid_answers=gl.page_manager_backend.get_page_names())
         dial.show(self.add_page_callback)
 
     def add_page_callback(self, name:str):
         path = os.path.join(gl.DATA_PATH, "pages", f"{name}.json")
-        gl.page_manager.add_page(name)
+        gl.page_manager_backend.add_page(name)
 
         # Notify plugin actions
         gl.signal_manager.trigger_signal(Signals.PageAdd, path)

--- a/src/windows/mainWindow/elements/PageSelector.py
+++ b/src/windows/mainWindow/elements/PageSelector.py
@@ -125,7 +125,7 @@ class PageSelector(Gtk.Box):
             return
         
         page_path = self.pages_model[drop_down.get_active()][1]
-        page = gl.page_manager.get_page(path=page_path, deck_controller = active_controller)
+        page = gl.page_manager_backend.get_page(path=page_path, deck_controller = active_controller)
         log.info(f"Load page: {page}")
         active_controller.load_page(page)
 

--- a/src/windows/mainWindow/elements/PageSelector.py
+++ b/src/windows/mainWindow/elements/PageSelector.py
@@ -130,8 +130,10 @@ class PageSelector(Gtk.Box):
         active_controller.load_page(page)
 
     def on_click_open_page_manager(self, button):
-        page_manager = PageManager(main_win=gl.app.main_win)
-        page_manager.present()
+        if gl.page_manager is not None:
+            gl.page_manager.present()
+        gl.page_manager = PageManager(main_win=gl.app.main_win)
+        gl.page_manager.present()
 
     def disconnect_change_signal(self):
         try:

--- a/src/windows/mainWindow/elements/Sidebar/Sidebar.py
+++ b/src/windows/mainWindow/elements/Sidebar/Sidebar.py
@@ -211,7 +211,7 @@ class PagesGroup(BetterPreferencesGroup):
         self.load_pages()
 
     def load_pages(self):
-        pages = gl.page_manager.get_pages()
+        pages = gl.page_manager_backend.get_pages()
         for page_path in pages:
             if os.path.dirname(page_path) != os.path.join(gl.DATA_PATH, "pages"):
                 continue

--- a/src/windows/mainWindow/elements/Sidebar/Sidebar.py
+++ b/src/windows/mainWindow/elements/Sidebar/Sidebar.py
@@ -80,7 +80,7 @@ class Sidebar(Adw.NavigationPage):
         self.error_page = ErrorPage(self)
         self.main_stack.add_named(self.error_page, "error_page")
 
-        self.page_selector = PageSelector(self.main_window, gl.page_manager, halign=Gtk.Align.CENTER)
+        self.page_selector = PageSelector(self.main_window, gl.page_manager_backend, halign=Gtk.Align.CENTER)
         self.header.set_title_widget(self.page_selector)
 
         self.load_for_coords((0, 0))

--- a/src/windows/mainWindow/mainWindow.py
+++ b/src/windows/mainWindow/mainWindow.py
@@ -221,7 +221,7 @@ class MainWindow(Adw.ApplicationWindow):
         if len(gl.deck_manager.deck_controller) == 0:
             self.set_main_error("no-decks")
 
-        elif len(gl.page_manager.get_page_names()) == 0:
+        elif len(gl.page_manager_backend.get_page_names()) == 0:
             self.set_main_error("no-pages")
 
         else:


### PR DESCRIPTION
Plugins can now Create Custom Events just like ActionHolders.
Events can be triggered by the Plugin itself by providing the specified ID
Events follow the Conventions of ActionHolders (An Event ID has to be specified)

The Events themselves implement the Observer pattern in an asynchronous way.
After a callback got connected to the Event, when it triggers the callback will be called async, when the callback is not specified as async a thread will be used to run the callback.
When this fails an error gets thrown and a async wait with a delay of 0 gets used instead to not disrupt the flow of the program.

I found no problems by always creating a new event loop, bigger scale tests may need to be run. Reverting the Changes is easy when it disrupts the program to much